### PR TITLE
fix: compwords is cleaner. force commits w FORCE=1 env

### DIFF
--- a/share/git-templates/hooks/pre-commit
+++ b/share/git-templates/hooks/pre-commit
@@ -20,6 +20,10 @@
 branch="$(git branch --show-current 2> /dev/null || git rev-parse --abbrev-ref HEAD)"
 
 if [ "$branch" = "master" ] || [ "$branch" = "main" ]; then
-  echo "You can't commit directly to '$branch' branch"
-  exit 1
+    if [ $FORCE = 1 ]; then
+        : nothing
+    else
+        echo "You can't commit directly to '$branch' branch"
+        exit 1
+    fi
 fi

--- a/share/shell/bashrc
+++ b/share/shell/bashrc
@@ -127,7 +127,8 @@ if [[ 1 == $USE_BASH_COMPLETION ]]; then
 
     __my_git_complete_heads()
     {
-        COMPREPLY=($(compgen -W '$(git for-each-ref --format="%(refname:strip=2)" "refs/heads/*" "refs/heads/*/**")' -- $2))
+        #COMPREPLY=($(compgen -W '$(git for-each-ref --format="%(refname:strip=2)" "refs/heads/*" "refs/heads/*/**")' -- $2))
+        COMPREPLY=($(compgen -W '$(git for-each-ref --format="%(refname:strip=2)" "refs/heads/*" "refs/heads/*/**")' -- ${COMP_WORDS[COMP_CWORD]}))
     }
     for cmd in gitbranchdelete gitbranchrename vco; do
         complete -F __my_git_complete_heads $cmd


### PR DESCRIPTION
* uses `COMP_WORDS` instead of `$2` for input
* `FORCE=1` is useful when starting new git repos and you need to commit to your local `main`