### PR TITLE
fix: automatically removes empty spaces EOL

### DIFF
--- a/share/vim/vimrc
+++ b/share/vim/vimrc
@@ -356,6 +356,8 @@ augroup ruby
         " this is cool when we are not in a Rails app
         au BufNewFile *.rb if !MyRailsDetect() | 0r ~/.config/vim/skeleton.rb | echo "# Turned off skeleton.rb" | endif
         au BufNewFile *.rake,Rakefile 0r ~/.config/vim/skeleton.rake
+        " automatically remove spaces at the end of the line
+        autocmd BufWritePre *.rb,*.rake,Rakefile :%s/\s\+$//e
     endif
 augroup END
 
@@ -366,6 +368,8 @@ augroup python
         au FileType   python set formatoptions=croq sm sw=4 sts=4 cindent cinkeys='0{,0},!^F,o,O,e' nu " files without extension
         " A simple python starter
         au BufNewFile *.py 0r ~/.config/vim/skeleton.py
+        " automatically remove spaces at the end of the line
+        autocmd BufWritePre *.py :%s/\s\+$//e
     endif
 augroup END
 
@@ -377,6 +381,8 @@ augroup shell
         au FileType sh set formatoptions=croq sm sw=4 sts=4 cindent cinkeys='0{,0},!^F,o,O,e' nu
         " On new files do..."
         au BufNewFile *.sh 0r ~/.config/vim/skeleton.sh
+        " automatically remove spaces at the end of the line
+        autocmd BufWritePre *.sh :%s/\s\+$//e
     endif
 augroup END
 


### PR DESCRIPTION
helps prevent cookstyle and other linters from complaining